### PR TITLE
Support importing decks from untap.in

### DIFF
--- a/src/components/BuildDeck.vue
+++ b/src/components/BuildDeck.vue
@@ -156,6 +156,13 @@ export default {
           let lines = x.split(/[\r\n]+/);
           for (let i = 0; i < lines.length; i++) {
             let line = lines[i];
+
+            // normalize from untap.in
+            let lineIsUntapSpecific = (line.indexOf('//') == 0)
+            if( lineIsUntapSpecific ) {
+              continue
+            }
+
             if (line !== "") {
               let spaceIndex = line.indexOf(" ");
               if (spaceIndex < 0) {


### PR DESCRIPTION
This PR adds a small conditional for supporting importing decks from `untap` by ignoring the "Play area" where cards are.