### PR TITLE
Feature: Adds deck sharing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "bootstrap-vue": "^2.22.0",
         "core-js": "^2.6.5",
         "dom-to-image": "^2.6.0",
+        "lz-string": "^1.5.0",
         "vue": "^2.6.10",
         "vue-router": "^3.5.3",
         "vue-select": "^3.18.3",
@@ -3154,6 +3155,14 @@
       "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
       "integrity": "sha1-hImxyw0p/4gZXM7KRI/21swpXDY=",
       "dev": true
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
     },
     "node_modules/magic-string": {
       "version": "0.26.2",
@@ -6866,6 +6875,11 @@
       "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
       "integrity": "sha1-hImxyw0p/4gZXM7KRI/21swpXDY=",
       "dev": true
+    },
+    "lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="
     },
     "magic-string": {
       "version": "0.26.2",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "bootstrap-vue": "^2.22.0",
     "core-js": "^2.6.5",
     "dom-to-image": "^2.6.0",
+    "lz-string": "^1.5.0",
     "vue": "^2.6.10",
     "vue-router": "^3.5.3",
     "vue-select": "^3.18.3",

--- a/src/App.vue
+++ b/src/App.vue
@@ -39,6 +39,7 @@
 
 <script>
 import PageNotFound from "./components/PageNotFound.vue";
+import lzString from "lz-string";
 
 export default {
   components: { PageNotFound },
@@ -87,8 +88,27 @@ export default {
         this.$store.commit("setLocalRoutes", []);
       }
     })
+
+    if (this.$route.query.deck) {
+      this.loadDeckFromUrl();
+      this.showSidebar = true;
+    }
   },
   methods: {
+    loadDeckFromUrl() {
+      this.$store.commit("clearDeck");
+      let deckString = this.$route.query.deck;
+      let deck = lzString.decompressFromEncodedURIComponent(deckString);
+      let parsedDeck = JSON.parse(deck);
+
+      Object.entries(parsedDeck).forEach(([cardName, count]) => {
+        while (count--) {
+          this.$store.commit("incrementCardToDeck", cardName);
+        }
+      });
+
+      this.$router.replace({ query: null });
+    },
     fixBackgroundHeight() {
       // Because CSS doesn't play well with all the crazy of mobile viewports...
       let height = 0;
@@ -122,7 +142,7 @@ export default {
 
       enableHover()
     }
-  },
+  }
 };
 </script>
 

--- a/src/components/spoiler/BuildDeck.vue
+++ b/src/components/spoiler/BuildDeck.vue
@@ -5,6 +5,11 @@
         <a href="#" @click.prevent="clear"><span class="font-default">✘</span> Clear</a>
       </div>
       <div class="float-right">
+
+        <a href="#" title="Share deck" class="mr-1" @click.prevent="shareDeck">
+          <font-awesome-icon icon="share" />
+        </a>
+
         <a href="#" @click.prevent="importCards" title="Load deck" class="mr-1">
           <font-awesome-icon icon="folder-open" />
         </a>
@@ -111,6 +116,7 @@
 import CardHover from "../shared/CardHover.vue";
 import CardLink from "../shared/CardLink.vue";
 import utility from "../../scripts/utility";
+import lzString from "lz-string";
 
 export default {
   name: "BuildDeck",
@@ -166,6 +172,11 @@ export default {
     },
   },
   methods: {
+    shareDeck() {
+      let deck = this.$store.state.deck;
+      let encodedDeck = lzString.compressToEncodedURIComponent(JSON.stringify(deck));
+      this.$router.push({ query: { deck: encodedDeck } });
+    },
     clear() {
       this.$store.commit("clearDeck");
     },

--- a/src/main.js
+++ b/src/main.js
@@ -16,9 +16,13 @@ Vue.filter('cardFormatter', function(value, prop, cardData) {
 })
 
 
-new Vue({
+let app = new Vue({
   router,
   render: h => h(App),
   store: store,
   beforeCreate() { this.$store.commit('initialize'); }
-}).$mount('#app')
+});
+
+router.onReady(() => {
+  app.$mount('#app');
+});

--- a/src/plugins/fontawesome.js
+++ b/src/plugins/fontawesome.js
@@ -16,7 +16,8 @@ import {
   faPlusSquare,
   faPrint,
   faSave,
-  faSignOutAlt
+  faSignOutAlt,
+  faShare
 } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 
@@ -35,5 +36,6 @@ library.add(faPlusSquare)
 library.add(faPrint)
 library.add(faSave)
 library.add(faSignOutAlt)
+library.add(faShare)
 
 Vue.component('font-awesome-icon', FontAwesomeIcon)


### PR DESCRIPTION
Hi team,

This PR adds deck sharing from the DeckBuilder view. I've added a "share" icon in the top row that, once clicked, will update the website's url with a `?deck=<compressed_deck>` query parameter. I could also put it on the clipboard but thought it a bit intrusive at the moment

<img width="307" alt="Screenshot 2025-04-01 at 11 19 01 PM" src="https://github.com/user-attachments/assets/58f5b604-061c-4f9b-bf02-8c4d5ebdf5e7" />

Once you have that url, you can share it pretty easily and also keep a Favorites folder with your saved decks!